### PR TITLE
decode recursively when reference is given

### DIFF
--- a/lib/Plack/Request/WithEncoding.pm
+++ b/lib/Plack/Request/WithEncoding.pm
@@ -81,9 +81,30 @@ sub _decode_parameters {
     my @flatten = $stuff->flatten;
     my @decoded;
     while ( my ($k, $v) = splice @flatten, 0, 2 ) {
-        push @decoded, $encoding->decode($k), $encoding->decode($v);
+        push @decoded, $self->_decode($encoding, $k), $self->_decode($encoding, $v);
     }
     return Hash::MultiValue->new(@decoded);
+}
+
+sub _decode {
+    my ($self, $encoding, $data) = @_;
+
+    if (ref $data eq "ARRAY") {
+        my @result;
+        for my $d (@$data) {
+            push @result, $self->_decode($encoding, $d);
+        }
+        return \@result;
+    }
+    elsif (ref $data eq "HASH") {
+        my %result;
+        while (my ($k, $v) = each %$data) {
+            $result{$self->_decode($encoding, $k)} = $self->_decode($encoding, $v);
+        }
+        return \%result;
+    }
+
+    return defined $data ? $encoding->decode($data) : undef;
 }
 
 1;


### PR DESCRIPTION
When HTTP::Entity::Parser::JSON is adopted as a parser, nested Hashref or Arrayref can be given as a request parameter.

In that case, like the reproduced code [here](https://gist.github.com/commojun/63653dc305cfb7fc5f93e53417952faf), the elements of Hashref and Arrayref cannot be properly decoded.

For example, a request like following
```
$ curl -X POST http://example/ -H 'content-type: application/json' -d '{ 
"foo":"bar",
"日本語":"日本語",
"hash": {
  "aaa": "あああ",
  "bbb": "bbb"
},
  "array": ["いいい", "ccc"]
}'
```

results in being treated like this:
```
$VAR1 = {
          "\x{65e5}\x{672c}\x{8a9e}" => "\x{65e5}\x{672c}\x{8a9e}",
          'hash' => 'HASH(0x55e63690cc08)',
          'array' => 'ARRAY(0x55e63690cc80)',
          'foo' => 'bar'
        };
```

So I made a fix to recursively decode the nested elements in that case.